### PR TITLE
Fabric update to 1.17.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.8-SNAPSHOT'
+	id 'fabric-loom' version '0.9-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/use
-	minecraft_version=1.17
-	yarn_mappings=1.17+build.1
-	loader_version=0.11.3
+	minecraft_version=1.17.1
+	yarn_mappings=1.17.1+build.32
+	loader_version=0.11.6
 
 # Mod Properties
 	mod_version = 1.1.1
@@ -13,4 +13,4 @@ org.gradle.jvmargs=-Xmx1G
 	archives_base_name = spawnermod
 
 # Dependencies
-	fabric_version=0.34.9+1.17
+	fabric_version=0.37.1+1.17

--- a/src/main/java/com/branders/spawnermod/gui/SpawnerConfigGui.java
+++ b/src/main/java/com/branders/spawnermod/gui/SpawnerConfigGui.java
@@ -365,7 +365,7 @@ public class SpawnerConfigGui extends Screen {
 	 * 	Close GUI
 	 */
 	private void close() {
-		client.openScreen((Screen)null);
+		client.setScreen((Screen)null);
 	}
 	
 	/**

--- a/src/main/java/com/branders/spawnermod/item/SpawnerKey.java
+++ b/src/main/java/com/branders/spawnermod/item/SpawnerKey.java
@@ -72,6 +72,6 @@ public class SpawnerKey extends Item {
 	@Environment(EnvType.CLIENT)
 	private void openSpawnerGui(MobSpawnerLogic logic, BlockPos pos) {
 		MinecraftClient mc = MinecraftClient.getInstance();
-		mc.openScreen(new SpawnerConfigGui(new TranslatableText(""), logic, pos));
+		mc.setScreen(new SpawnerConfigGui(new TranslatableText(""), logic, pos));
 	}
 }


### PR DESCRIPTION
First ever pull request so feedback is great if something can be improved

Update to 1.17.1 mappings, update client.openScreen to client.setScreen for SpawnerConfigGui and SpawnerKey after reloading new mappings. Ran build and confirmed SpawnerConfigGui works in 1.17.1 fabric environment.