### PR TITLE
add forge 1.19.4 compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,14 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 # Minecraft version
-mc_version=1.19.3
+mc_version=1.19.4
 
 # Mappings version
 mappings_channel=official
-mappings_version=1.19
+mappings_version=1.19.4
 
 # Minecraft Forge version
-forge_version=44.1.4
+forge_version=45.1.16
 
 # SpongePowered Mixin version (commented out by default)
 mixin_version=0.8.4

--- a/src/main/java/com/branders/spawnermod/event/SpawnerEventHandler.java
+++ b/src/main/java/com/branders/spawnermod/event/SpawnerEventHandler.java
@@ -70,7 +70,7 @@ public class SpawnerEventHandler {
 						ConfigValues.get("limited_spawns_amount"),
 						ConfigValues.get("default_spawner_range_enabled"),
 						ConfigValues.get("default_spawner_range")),
-				player.connection.getConnection(),
+				player.connection.connection,
 				NetworkDirection.PLAY_TO_CLIENT);
 	}
 
@@ -327,7 +327,7 @@ public class SpawnerEventHandler {
 		level.addFreshEntity(entityItem);
 
 		// Replace the entity inside the spawner with default entity
-		logic.m_253197_(EntityType.AREA_EFFECT_CLOUD, level, level.random, pos);
+		logic.setEntityId(EntityType.AREA_EFFECT_CLOUD, level, level.random, pos);
 		spawner.setChanged();
 		level.sendBlockUpdated(pos, blockstate, blockstate, 3);
 	}

--- a/src/main/java/com/branders/spawnermod/gui/SpawnerConfigGui.java
+++ b/src/main/java/com/branders/spawnermod/gui/SpawnerConfigGui.java
@@ -179,7 +179,7 @@ public class SpawnerConfigGui extends Screen {
 		/**
 		 * 	Count button
 		 */
-		countButton = addRenderableWidget(Button.m_253074_(
+		countButton = addRenderableWidget(Button.builder(
 				Component.translatable("button.count." + getButtonText(countOptionValue)), button -> {
 					switch(countOptionValue) {
 					// Low, set to Default
@@ -212,14 +212,14 @@ public class SpawnerConfigGui extends Screen {
 					}
 					countButton.setMessage(Component.translatable("button.count." + getButtonText(countOptionValue)));
 				})
-				.m_252987_(width / 2 - 48, 55, 108, 20)
-				.m_253136_());
+				.bounds(width / 2 - 48, 55, 108, 20)
+				.build());
 
 
 		/**
 		 * 	Speed button
 		 */
-		speedButton = addRenderableWidget(Button.m_253074_(
+		speedButton = addRenderableWidget(Button.builder(
 				Component.translatable("button.speed." + getButtonText(speedOptionValue)), button -> {
 					switch(speedOptionValue) {
 					// Slow, set to default
@@ -256,13 +256,13 @@ public class SpawnerConfigGui extends Screen {
 					}
 					speedButton.setMessage(Component.translatable("button.speed." + getButtonText(speedOptionValue)));
 				})
-				.m_252987_(width / 2 - 48, 80, 108, 20)
-				.m_253136_());
+				.bounds(width / 2 - 48, 80, 108, 20)
+				.build());
 
 		/**
 		 * 	Range button
 		 */
-		rangeButton = addRenderableWidget(Button.m_253074_(
+		rangeButton = addRenderableWidget(Button.builder(
 				Component.translatable("button.range." + getButtonText(rangeOptionValue)).append(" " + requiredPlayerRange), button -> {
 					switch(rangeOptionValue) {
 					// Default, set to Far
@@ -303,13 +303,13 @@ public class SpawnerConfigGui extends Screen {
 
 					rangeButton.setMessage(Component.translatable("button.range." + getButtonText(rangeOptionValue)).append(" " + requiredPlayerRange));
 				})
-				.m_252987_(width / 2 - 48, 105, 108, 20)
-				.m_253136_());
+				.bounds(width / 2 - 48, 105, 108, 20)
+				.build());
 
 		/**
 		 * 	Disable button
 		 */
-		disableButton = addRenderableWidget(Button.m_253074_(
+		disableButton = addRenderableWidget(Button.builder(
 				Component.translatable("button.toggle." + getButtonText(disabled)), button -> {
 					if(disabled) {
 						// Set spawner to ON
@@ -339,23 +339,23 @@ public class SpawnerConfigGui extends Screen {
 
 					disableButton.setMessage(Component.translatable("button.toggle." + getButtonText(disabled)));
 				})
-				.m_252987_(width / 2 - 48, 130, 108, 20)
-				.m_253136_());
+				.bounds(width / 2 - 48, 130, 108, 20)
+				.build());
 
 		/**
 		 * 	Save button - configures spawner data
 		 */
-		addRenderableWidget(Button.m_253074_(Component.translatable("button.save"), button -> {
+		addRenderableWidget(Button.builder(Component.translatable("button.save"), button -> {
 			configureSpawner();
 			this.close();
-		}).m_252987_(width / 2 - 89, 180 + 10, 178, 20).m_253136_());
+		}).bounds(width / 2 - 89, 180 + 10, 178, 20).build());
 
 		/**
 		 * 	Cancel button
 		 */
-		addRenderableWidget(Button.m_253074_(Component.translatable("button.cancel"), button -> {
+		addRenderableWidget(Button.builder(Component.translatable("button.cancel"), button -> {
 			this.close();
-		}).m_252987_(width / 2 - 89, 180 + 35, 178, 20).m_253136_());
+		}).bounds(width / 2 - 89, 180 + 35, 178, 20).build());
 
 
 		if(disabled)
@@ -368,7 +368,7 @@ public class SpawnerConfigGui extends Screen {
 	 * 	Render GUI Texture
 	 */
 	@Override
-	public void m_86412_(PoseStack matrixStack, int mouseX, int mouseY, float partialTicks) {
+	public void render(PoseStack matrixStack, int mouseX, int mouseY, float partialTicks) {
 		RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
 
 		// Draw black transparent background (just like when pressing escape)
@@ -392,7 +392,7 @@ public class SpawnerConfigGui extends Screen {
 		}
 
 		// Render other stuff as well (buttons)
-		super.m_86412_(matrixStack, mouseX, mouseY, partialTicks);
+		super.render(matrixStack, mouseX, mouseY, partialTicks);
 	}
 
 	/**

--- a/src/main/java/com/branders/spawnermod/mixin/LimitedSpawnsMixin.java
+++ b/src/main/java/com/branders/spawnermod/mixin/LimitedSpawnsMixin.java
@@ -68,7 +68,7 @@ public class LimitedSpawnsMixin {
         	nbt = logic.save(nbt);
         	nbt.putShort("RequiredPlayerRange", (short) 0);
         	logic.load(level, pos, nbt);
-        	logic.m_253197_(EntityType.AREA_EFFECT_CLOUD, level, level.random, pos);
+        	logic.setEntityId(EntityType.AREA_EFFECT_CLOUD, level, level.random, pos);
         	level.levelEvent(LevelEvent.LAVA_FIZZ, pos, 0);
         	ci.cancel();
         }

--- a/src/main/java/com/branders/spawnermod/networking/packet/SyncSpawnerEggDrop.java
+++ b/src/main/java/com/branders/spawnermod/networking/packet/SyncSpawnerEggDrop.java
@@ -91,7 +91,7 @@ public class SyncSpawnerEggDrop
 				level.addFreshEntity(entityItem);
 				
 				// Replace the entity inside the spawner with default entity
-				logic.m_253197_(EntityType.AREA_EFFECT_CLOUD, level, level.random, msg.pos);
+				logic.setEntityId(EntityType.AREA_EFFECT_CLOUD, level, level.random, msg.pos);
 				spawner.setChanged();
 				level.sendBlockUpdated(msg.pos, blockstate, blockstate, 3);
 			}

--- a/src/main/java/com/branders/spawnermod/registry/ItemRegistry.java
+++ b/src/main/java/com/branders/spawnermod/registry/ItemRegistry.java
@@ -30,7 +30,7 @@ public class ItemRegistry {
 	
 	@SubscribeEvent
 	public void buildContents(CreativeModeTabEvent.BuildContents event) {
-		if (event.getTab() == CreativeModeTabs.f_256869_) {
+		if (event.getTab() == CreativeModeTabs.TOOLS_AND_UTILITIES) {
 			event.accept(SPAWNER_KEY);
 		}
 	}


### PR DESCRIPTION
I made this branch off commit 7cae4094972edb6cbccbe5c7b93fe795174f2fb6, but I'm not sure how to make a pull request (or if I even can) in github from a specific commit. 

I chose that commit because the only thing after it on the forge branch is the 1.20.1 update.  While 1.20.1 looks to have updated gradle and lots of build aspects, all of the changes needed to bump from 1.19.3 to 1.19.4 were found in the code from the 1.20.1 update. 

I've tested this on single player, by toggling to creative, making a spawner and silk touch diamond pick,  then going back to survival and mining the spawner. that worked correctly.
Also tested by installing this mod on my multiplayer server. used the above process both without the mod (works as expected, simply destroys the spawner), then adding the mod because correctly with providing an empty spawner and the related egg.

If there's anything else I can do to help add this for others, please let me know. I've seen people on the forge mod website comments asking for this, but also noticed your note about dealing with life things these days so I'll help get this sorted as much as I can if you are interested in making this available to others.